### PR TITLE
gblocks admin link did not work for non superusers, fixed.

### DIFF
--- a/django_generic_flatblocks/templatetags/generic_flatblocks.py
+++ b/django_generic_flatblocks/templatetags/generic_flatblocks.py
@@ -40,7 +40,7 @@ class GenericFlatblockNode(Node):
         module_name = related_object._meta.module_name
         # Check if user has change permissions
         if context['request'].user.is_authenticated() and \
-           context['request'].user.has_perm('%s.change' % module_name):
+           context['request'].user.has_perm('%s.change_%s' % (app_label, module_name)):
             admin_url_prefix = getattr(settings, 'ADMIN_URL_PREFIX', '/admin/')
             return '%s%s/%s/%s/' % (admin_url_prefix, app_label, module_name, related_object.pk)
         else:


### PR DESCRIPTION
If you set up a staff user with proper permissions to gblocks the admin link still won't appear. This one-liner fixes that.
