### PR TITLE
Replaced `module_name` with `model_name`

### DIFF
--- a/django_generic_flatblocks/admin.py
+++ b/django_generic_flatblocks/admin.py
@@ -24,7 +24,7 @@ class GenericFlatblockAdmin(admin.ModelAdmin):
     def generate_related_object_admin_link(self, related_object):
         return '../../%s/%s/%s/' % (
             related_object._meta.app_label,
-            related_object._meta.module_name,
+            related_object._meta.model_name,
             related_object.pk
         )
 
@@ -39,7 +39,7 @@ class GenericFlatblockAdmin(admin.ModelAdmin):
             'admin_url': self.generate_related_object_admin_link(related_object),
             'related_object': related_object,
             'related_app_label': related_object._meta.app_label,
-            'related_module_name': related_object._meta.module_name,
+            'related_model_name': related_object._meta.model_name,
         }
         c.update(extra_context or {})
         self.change_form_template = 'admin/django_generic_flatblocks/change_form_forward.html'

--- a/django_generic_flatblocks/locale/de/LC_MESSAGES/django.po
+++ b/django_generic_flatblocks/locale/de/LC_MESSAGES/django.po
@@ -46,11 +46,11 @@ msgstr "Hinweis"
 #, python-format
 msgid ""
 "This object stores only the path to the related <em>%(related_app_label)s/%"
-"(related_module_name)s</em> object with the primary key <em>%(related_pk)s</"
+"(related_model_name)s</em> object with the primary key <em>%(related_pk)s</"
 "em>."
 msgstr ""
 "Dieses Objekt enthält nur den Pfad zum verknüpften <em>%(related_app_label)s/"
-"%(related_module_name)s</em> Objekt mit dem Primärschlüssel <em>%(related_pk)"
+"%(related_model_name)s</em> Objekt mit dem Primärschlüssel <em>%(related_pk)"
 "s</em>."
 
 #: templates/admin/django_generic_flatblocks/change_form_forward.html:9

--- a/django_generic_flatblocks/locale/dk/LC_MESSAGES/django.po
+++ b/django_generic_flatblocks/locale/dk/LC_MESSAGES/django.po
@@ -47,11 +47,11 @@ msgstr "Notifikation"
 #, python-format
 msgid ""
 "This object stores only the path to the related <em>%(related_app_label)s/%"
-"(related_module_name)s</em> object with the primary key <em>%(related_pk)s</"
+"(related_model_name)s</em> object with the primary key <em>%(related_pk)s</"
 "em>."
 msgstr ""
 "Dette objekt gemmer udelukkende stien til det relaterede <em>%(related_app_label)s/%"
-"(related_module_name)s</em> objekt med den primære nøgle <em>%(related_pk)s</"
+"(related_model_name)s</em> objekt med den primære nøgle <em>%(related_pk)s</"
 "em>."
 
 #: templates/admin/django_generic_flatblocks/change_form_forward.html:9

--- a/django_generic_flatblocks/locale/en/LC_MESSAGES/django.po
+++ b/django_generic_flatblocks/locale/en/LC_MESSAGES/django.po
@@ -46,7 +46,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This object stores only the path to the related <em>%(related_app_label)s/%"
-"(related_module_name)s</em> object with the primary key <em>%(related_pk)s</"
+"(related_model_name)s</em> object with the primary key <em>%(related_pk)s</"
 "em>."
 msgstr ""
 

--- a/django_generic_flatblocks/locale/fr/LC_MESSAGES/django.po
+++ b/django_generic_flatblocks/locale/fr/LC_MESSAGES/django.po
@@ -48,11 +48,11 @@ msgstr "Note"
 #, python-format
 msgid ""
 "This object stores only the path to the related <em>%(related_app_label)s/"
-"%(related_module_name)s</em> object with the primary key <em>%(related_pk)s</"
+"%(related_model_name)s</em> object with the primary key <em>%(related_pk)s</"
 "em>."
 msgstr ""
 "Cet objet ne sert que de liaison vers l'objet <em>%(related_app_label)s/"
-"%(related_module_name)s</em> avec la clé primaire <em>%(related_pk)s</"
+"%(related_model_name)s</em> avec la clé primaire <em>%(related_pk)s</"
 "em>."
 
 

--- a/django_generic_flatblocks/templates/admin/django_generic_flatblocks/change_form_forward.html
+++ b/django_generic_flatblocks/templates/admin/django_generic_flatblocks/change_form_forward.html
@@ -4,7 +4,7 @@
 {% block content %}
     <p style="margin: 2em 0 0.5em 0; color: #555;">
         <strong style="color: #c00;">{% trans "Notice" %}:</strong>
-        {% blocktrans with related_object.pk as related_pk %}This object stores only the path to the related <em>{{related_app_label}}/{{related_module_name}}</em> object with the primary key <em>{{ related_pk }}</em>.{% endblocktrans %}</p>
+        {% blocktrans with related_object.pk as related_pk %}This object stores only the path to the related <em>{{related_app_label}}/{{related_model_name}}</em> object with the primary key <em>{{ related_pk }}</em>.{% endblocktrans %}</p>
     <p style="margin: 0.5em 0 3em 0;"><a style="font-weight: bold;" href="../{{ admin_url }}"
             >{% trans "Click this link to edit the object itself." %}</a>        
     {{ block.super }}

--- a/django_generic_flatblocks/templatetags/generic_flatblocks.py
+++ b/django_generic_flatblocks/templatetags/generic_flatblocks.py
@@ -37,13 +37,13 @@ class GenericFlatblockNode(Node):
         will work automatically using urlresolvers.
         """
         app_label = related_object._meta.app_label
-        module_name = related_object._meta.model_name
+        model_name = related_object._meta.model_name
 
         # Check if user has change permissions
         if context['request'].user.is_authenticated() and \
-           context['request'].user.has_perm('%s.change' % module_name):
+           context['request'].user.has_perm('%s.change' % model_name):
             admin_url_prefix = getattr(settings, 'ADMIN_URL_PREFIX', '/admin/')
-            return '%s%s/%s/%s/' % (admin_url_prefix, app_label, module_name, related_object.pk)
+            return '%s%s/%s/%s/' % (admin_url_prefix, app_label, model_name, related_object.pk)
         else:
             return None
 


### PR DESCRIPTION
From [the "Features removed in 1.8" section of the Django 1.8 release notes](https://docs.djangoproject.com/en/1.9/releases/1.8/#features-removed-in-1-8):

The `Model._meta.module_name` alias is removed.

[More information from the Django 1.6 release notes](https://docs.djangoproject.com/en/1.9/releases/1.6/#module-name-model-meta-attribute)
